### PR TITLE
Fix RankN function when n greater than 10

### DIFF
--- a/lexorank.go
+++ b/lexorank.go
@@ -2,6 +2,7 @@ package lexorank
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 )
 
@@ -59,9 +60,12 @@ func RankN(prev, next string, n int) ([]string, error) {
 		return nil, err
 	}
 
+	suffixRankLen := len(strconv.Itoa(n))
+	suffixRankFormat := fmt.Sprintf("%%0%dd", suffixRankLen)
+
 	res := make([]string, 0, n)
 	for i := 0; i < n; i++ {
-		res = append(res, idx+strconv.Itoa(i))
+		res = append(res, idx+fmt.Sprintf(suffixRankFormat, i))
 	}
 	return res, nil
 }

--- a/lexorank_test.go
+++ b/lexorank_test.go
@@ -58,6 +58,7 @@ func TestRankN(t *testing.T) {
 		{"az", "b", 3, []string{"azU0", "azU1", "azU2"}, false},
 		{"a", "d", 2, []string{"b0", "b1"}, false},
 		{"a", "c", 4, []string{"b0", "b1", "b2", "b3"}, false},
+		{"0", "z", 20, []string{"U00", "U01", "U02", "U03", "U04", "U05", "U06", "U07", "U08", "U09", "U10", "U11", "U12", "U13", "U14", "U15", "U16", "U17", "U18", "U19"}, false},
 		{"a", "_", 4, []string{"b0", "b1", "b2", "b3"}, true},
 	}
 


### PR DESCRIPTION
First of all, I would like to express my gratitude for the usefulness of this library. It has been incredibly helpful in my projects.

I am using the function RankN, i had a bug
```go
ranks, err := lexorank.RankN("0", "z", 20)
// It return U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19
// Expect: U00, U01, U02, U03, U04, U05, U06, U07, U08, U09, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19
```
So i am submitting this pull request to fix this issue.